### PR TITLE
Avoid number of test cases increasing with each run of the CI system

### DIFF
--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -18,6 +18,8 @@ class DeletyComparisonTester(xmostest.ComparisonTester):
 
     def run(self, output):
         super(DeletyComparisonTester, self).run(output)
+
+    def __del__(self):
         shutil.rmtree(self.d)
 
 


### PR DESCRIPTION
The random number generator is now seeded with the current git hash of the repo, so that a given snapshot of the library will always get the same sequence of seeds when generating it’s test programs.
