### PR TITLE
Fix for BuildBot source check

### DIFF
--- a/lib_dsp/api/dsp_vector.h
+++ b/lib_dsp/api/dsp_vector.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2018, XMOS Ltd, All rights reserved
 
 #ifndef DSP_VECTOR_H_
 #define DSP_VECTOR_H_


### PR DESCRIPTION
The script had to be run twice to pass the check.