### PR TITLE
Initial conversion for use on XS3 platforms

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ xCORE-200 DSP library change log
 6.0.2
 -----
 
-  * CHANGED: use XS2 version of dsp_fft_bit_reverse() on XS3
+  * CHANGED: use XS2 version of platform-specific functions on XS3
 
 6.0.1
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 xCORE-200 DSP library change log
 ================================
 
+6.0.2
+-----
+
+  * CHANGED: use XS2 version of dsp_fft_bit_reverse() on XS3
+
 6.0.1
 -----
 

--- a/lib_dsp/api/dsp_bfp.h
+++ b/lib_dsp/api/dsp_bfp.h
@@ -233,7 +233,7 @@ void dsp_div_bfp_vect_complex_int32(
     int32_t * UNSAFE c, int   c_exp, unsigned   c_hr,
     unsigned length);
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 
 /** This function computes the number of leading sign bits in an array of

--- a/lib_dsp/api/dsp_math.h
+++ b/lib_dsp/api/dsp_math.h
@@ -242,7 +242,7 @@ inline q8_24 dsp_math_cos(q8_24 rad) {
  */
 q8_24 dsp_math_atan(q8_24 x);
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 /** Function that computes a fast fixed point atan2 and hypothenuse. The input
  * comprises an array of two integers (notionally a complex number with the
  * real value stored in the first index, and the imaginary value stored in

--- a/lib_dsp/module_build_info
+++ b/lib_dsp/module_build_info
@@ -1,4 +1,4 @@
-VERSION = 6.0.1
+VERSION = 6.0.2
 
 DEPENDENT_MODULES = lib_logging(>=3.0.0)
 

--- a/lib_dsp/src/bfp/dsp_bfp_bit_reverse_shl.S
+++ b/lib_dsp/src/bfp/dsp_bfp_bit_reverse_shl.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/bfp/dsp_bfp_cls.S
+++ b/lib_dsp/src/bfp/dsp_bfp_cls.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 #define NSTACKWORDS 2
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/bfp/dsp_bfp_shl.S
+++ b/lib_dsp/src/bfp/dsp_bfp_shl.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 #undef NSTACKWORDS
 #define NSTACKWORDS 0

--- a/lib_dsp/src/dsp_biquad.S
+++ b/lib_dsp/src/dsp_biquad.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2017-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2017-2020, XMOS Ltd, All rights reserved
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 #define NSTACKWORDS 8
 

--- a/lib_dsp/src/dsp_complex.xc
+++ b/lib_dsp/src/dsp_complex.xc
@@ -28,7 +28,7 @@ dsp_complex_t dsp_complex_mul_conjugate(dsp_complex_t a, dsp_complex_t b, uint32
     return sum;
 }
 
-#if !defined(__XS2A__)
+#if !defined(__XS2A__) && !defined(__XS3A__)
 dsp_complex_t dsp_complex_fir(dsp_complex_t a[], dsp_complex_t b[],
                               uint32_t L, uint32_t off, uint32_t N) {
     int64_t re = 0;
@@ -42,7 +42,7 @@ dsp_complex_t dsp_complex_fir(dsp_complex_t a[], dsp_complex_t b[],
 }
 #endif
 
-#if !defined(__XS2A__)
+#if !defined(__XS2A__) && !defined(__XS3A__)
 void dsp_complex_mul_vector(dsp_complex_t a[], dsp_complex_t b[],
                                      uint32_t L, uint32_t N) {
     for(unsigned i = 0; i < L; i++) {
@@ -51,7 +51,7 @@ void dsp_complex_mul_vector(dsp_complex_t a[], dsp_complex_t b[],
 }
 #endif
 
-#if !defined(__XS2A__)
+#if !defined(__XS2A__) && !defined(__XS3A__)
 void dsp_complex_mul_conjugate_vector(dsp_complex_t a[], dsp_complex_t b[],
                                      uint32_t L, uint32_t N) {
     for(unsigned i = 0; i < L; i++) {
@@ -60,7 +60,7 @@ void dsp_complex_mul_conjugate_vector(dsp_complex_t a[], dsp_complex_t b[],
 }
 #endif
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 void dsp_complex_magnitude_vector(uint32_t magnitude[],
                                   dsp_complex_t input[],
                                   uint32_t N, uint32_t P) {

--- a/lib_dsp/src/dsp_complex_add_vector.S
+++ b/lib_dsp/src/dsp_complex_add_vector.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     
 #define NSTACKWORDS 2
 

--- a/lib_dsp/src/dsp_complex_fir.S
+++ b/lib_dsp/src/dsp_complex_fir.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/dsp_complex_hann.S
+++ b/lib_dsp/src/dsp_complex_hann.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     
 #define NSTACKWORDS 6
 

--- a/lib_dsp/src/dsp_complex_mul_vector.S
+++ b/lib_dsp/src/dsp_complex_mul_vector.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/dsp_fast_atan.S
+++ b/lib_dsp/src/dsp_fast_atan.S
@@ -1,5 +1,5 @@
-// Copyright (c) 2015-2016, XMOS Ltd, All rights reserved
-#if defined(__XS2A__)
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
+#if defined(__XS2A__) || defined(__XS3A__)
     
 #define ITER(X) \
 	{bf t, y_negative_ ## X         ; add j, j, 1}; \

--- a/lib_dsp/src/dsp_fast_float.xc
+++ b/lib_dsp/src/dsp_fast_float.xc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2018-2020, XMOS Ltd, All rights reserved
 #include <xs1.h>
 #include <xclib.h>
 #include <limits.h>
@@ -411,7 +411,7 @@ dsp_u32_float_t dsp_sqrt_u32(const dsp_u32_float_t a){
 
         dsp_sqrt_calc_exp(a.e, clz(a.m), &shl, &b.e);
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
         if(shl > 0)
             b.m = dsp_sqrt30_xs2(a.m<<shl);
         else

--- a/lib_dsp/src/dsp_filters.c
+++ b/lib_dsp/src/dsp_filters.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
 
 
 #include <platform.h>
@@ -1476,7 +1476,7 @@ int32_t dsp_filters_biquad
     int32_t*       state_data,
     const int32_t q_format
 ) {
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     return dsp_filters_biquads(input_sample, filter_coeffs, state_data, 1, q_format);
     #else
     return 0;

--- a/lib_dsp/src/dsp_logistics.S
+++ b/lib_dsp/src/dsp_logistics.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 #define NSTACKWORDS  0
     

--- a/lib_dsp/src/dsp_min_vector.S
+++ b/lib_dsp/src/dsp_min_vector.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     
 #define NSTACKWORDS 2
 

--- a/lib_dsp/src/dsp_poly_eval.S
+++ b/lib_dsp/src/dsp_poly_eval.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2017-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2017-2020, XMOS Ltd, All rights reserved
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 #define NSTACKWORDS 4
 

--- a/lib_dsp/src/dsp_sqrt_xs2.S
+++ b/lib_dsp/src/dsp_sqrt_xs2.S
@@ -1,9 +1,9 @@
-// Copyright (c) 2016-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2016-2020, XMOS Ltd, All rights reserved
     
 	.section	.dp.data,"awd",@progbits
 	.text
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 	.cc_top dsp_sqrt30_xs2.function
 	.globl	dsp_sqrt30_xs2
 	.type	dsp_sqrt30_xs2,@function

--- a/lib_dsp/src/fft/dsp_fft.xc
+++ b/lib_dsp/src/fft/dsp_fft.xc
@@ -1,11 +1,11 @@
-// Copyright (c) 2015-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
 #include <xs1.h>
 #include <xclib.h>
 #include <stdint.h>
 #include <stdio.h>
 #include "dsp_fft.h"
 
-#ifndef __XS2A__
+#if !defined(__XS2A__) && !defined(__XS3A__)
 void dsp_fft_bit_reverse( dsp_complex_t pts[], const uint32_t N )
 {
 #warning "Bit reverse code in dsp_fft_bit_reverse not verified for XS1"

--- a/lib_dsp/src/fft/dsp_fft.xc
+++ b/lib_dsp/src/fft/dsp_fft.xc
@@ -223,7 +223,7 @@ void dsp_fft_inverse_DIF_xs1 (
     }
 }
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 extern void dsp_fft_forward_xs2 (
         dsp_complex_t pts[],
@@ -249,7 +249,7 @@ void dsp_fft_forward (
     dsp_complex_t pts[],
     const uint32_t  N,
     const int32_t   sine[] ){
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     dsp_fft_forward_xs2 (pts, (uint32_t) N, sine);
 #else
     dsp_fft_forward_xs1 (pts, N, sine);
@@ -260,7 +260,7 @@ void dsp_fft_inverse (
     dsp_complex_t pts[],
     const uint32_t  N,
     const int32_t   sine[] ){
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     dsp_fft_inverse_xs2 (pts, (uint32_t) N, sine);
 #else
     dsp_fft_inverse_xs1 (pts, N, sine);
@@ -269,7 +269,7 @@ void dsp_fft_inverse (
 
 
 void dsp_fft_split_spectrum( dsp_complex_t pts[], const uint32_t N ){
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     dsp_fft_split_spectrum_xs2(pts, (uint32_t) N);
 #else
     for(uint32_t i=1;i<N/2;i++){
@@ -302,7 +302,7 @@ void dsp_fft_split_spectrum( dsp_complex_t pts[], const uint32_t N ){
 }
 
 void dsp_fft_merge_spectra( dsp_complex_t pts[], const uint32_t N ){
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     dsp_fft_merge_spectra_xs2(pts, (uint32_t) N);
 #else
     for(uint32_t i=1;i<N/4;i++){
@@ -332,7 +332,7 @@ void dsp_fft_merge_spectra( dsp_complex_t pts[], const uint32_t N ){
 }
 
 void dsp_fft_short_to_long( const dsp_complex_short_t s[], dsp_complex_t l[], const uint32_t N ) {
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     dsp_fft_short_to_long_xs2(s, l, (uint32_t) N);
 #else
     for(uint32_t i=0;i<N;i++){
@@ -343,7 +343,7 @@ void dsp_fft_short_to_long( const dsp_complex_short_t s[], dsp_complex_t l[], co
 }
 
 void dsp_fft_long_to_short( const dsp_complex_t l[], dsp_complex_short_t s[], const uint32_t N ) {
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     dsp_fft_long_to_short_xs2(l, s, (uint32_t) N);
 #else
     for(uint32_t i=0;i<N;i++){

--- a/lib_dsp/src/fft/dsp_fft_bit_reverse.S
+++ b/lib_dsp/src/fft/dsp_fft_bit_reverse.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/fft/dsp_fft_forward.S
+++ b/lib_dsp/src/fft/dsp_fft_forward.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/fft/dsp_fft_gc.S
+++ b/lib_dsp/src/fft/dsp_fft_gc.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2018, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/fft/dsp_fft_inverse.S
+++ b/lib_dsp/src/fft/dsp_fft_inverse.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/fft/dsp_fft_inverse_DIF.S
+++ b/lib_dsp/src/fft/dsp_fft_inverse_DIF.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2018, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/fft/dsp_fft_merge_spectra.S
+++ b/lib_dsp/src/fft/dsp_fft_merge_spectra.S
@@ -1,9 +1,9 @@
-// Copyright (c) 2016-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2016-2020, XMOS Ltd, All rights reserved
     
 	.section	.dp.data,"awd",@progbits
 	.text
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 	.cc_top dsp_fft_merge_spectra_xs2.function
 	.globl	dsp_fft_merge_spectra_xs2
 	.align	4

--- a/lib_dsp/src/fft/dsp_fft_real.xc
+++ b/lib_dsp/src/fft/dsp_fft_real.xc
@@ -80,7 +80,7 @@ void dsp_fft_bit_reverse_and_forward_real (
     dsp_fft_bit_reverse((pts, dsp_complex_t[]), N>>1);
     dsp_fft_forward((pts, dsp_complex_t[]), N>>1, sine);
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     dsp_fft_real_fix_forward_xs2((pts, dsp_complex_t[]), N>>1, sin2);
 #endif
 }
@@ -91,7 +91,7 @@ void dsp_fft_bit_reverse_and_inverse_real (
     const int32_t sine[],
     const int32_t sin2[] ) {
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
     dsp_fft_real_fix_inverse_xs2((pts, dsp_complex_t[]), N>>1, sin2);
 #endif
     dsp_fft_bit_reverse((pts, dsp_complex_t[]), N>>1);

--- a/lib_dsp/src/fft/dsp_fft_real_fix.S
+++ b/lib_dsp/src/fft/dsp_fft_real_fix.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 #undef NSTACKWORDS
 #define NSTACKWORDS 16

--- a/lib_dsp/src/fft/dsp_fft_split_spectrum.S
+++ b/lib_dsp/src/fft/dsp_fft_split_spectrum.S
@@ -1,9 +1,9 @@
-// Copyright (c) 2015-2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
 	.section	.dp.data,"awd",@progbits
 	.text
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 	.cc_top dsp_fft_split_spectrum_xs2.function
 	.globl	dsp_fft_split_spectrum_xs2
 	.align	4

--- a/lib_dsp/src/fft/dsp_fft_zero_reverse_forward.S
+++ b/lib_dsp/src/fft/dsp_fft_zero_reverse_forward.S
@@ -1,6 +1,6 @@
-// Copyright (c) 2015-2017, XMOS Ltd, All rights reserved
+// Copyright (c) 2015-2020, XMOS Ltd, All rights reserved
     
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 
 	.text
     .issue_mode  dual

--- a/lib_dsp/src/fft/dsp_long_short_conversion.S
+++ b/lib_dsp/src/fft/dsp_long_short_conversion.S
@@ -1,9 +1,9 @@
-// Copyright (c) 2016, XMOS Ltd, All rights reserved
+// Copyright (c) 2016-2020, XMOS Ltd, All rights reserved
     
 	.section	.dp.data,"awd",@progbits
 	.text
 
-#if defined(__XS2A__)
+#if defined(__XS2A__) || defined(__XS3A__)
 	.cc_top dsp_fft_short_to_long_xs2.function
 	.globl	dsp_fft_short_to_long_xs2
 	.align	4

--- a/lib_dsp/src/poly_eval.c
+++ b/lib_dsp/src/poly_eval.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2019, XMOS Ltd, All rights reserved
+// Copyright (c) 2019-2020, XMOS Ltd, All rights reserved
 #include <stdint.h>
 
 int32_t dsp_poly_eval_impl_xs2
@@ -14,8 +14,8 @@ int32_t dsp_poly_eval
     const int32_t * coefs,
     const unsigned n_coefs
 ){
-#
-#if defined(__XS2A__)
+
+#if defined(__XS2A__) || defined(__XS3A__)
     return dsp_poly_eval_impl_xs2(x, coefs, n_coefs);
 #else
     int32_t r = coefs[n_coefs-1];


### PR DESCRIPTION
Use XS2 version of platform-specific functions on XS3.  Addresses issue #169.  The unit tests for lib_dsp pass on both XS2 (using axe) and XS3 (using the xcore-ai explorer board).