### PR TITLE
Re-apply original copyright years

### DIFF
--- a/AN00209_xCORE-200_DSP_Library/app_atan2_hypot/src/app_atan2_hypot.xc
+++ b/AN00209_xCORE-200_DSP_Library/app_atan2_hypot/src/app_atan2_hypot.xc
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // XMOS DSP Library - DCT Functions test program
 

--- a/AN00209_xCORE-200_DSP_Library/app_bfp/src/app_bfp.xc
+++ b/AN00209_xCORE-200_DSP_Library/app_bfp/src/app_bfp.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // XMOS DSP Library - DCT Functions test program
 

--- a/AN00209_xCORE-200_DSP_Library/app_complex/src/app_complex.xc
+++ b/AN00209_xCORE-200_DSP_Library/app_complex/src/app_complex.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // XMOS DSP Library - Filtering Functions Test Program
 // Uses Q24 format

--- a/AN00209_xCORE-200_DSP_Library/app_complex_fir/src/app_complex_filters.xc
+++ b/AN00209_xCORE-200_DSP_Library/app_complex_fir/src/app_complex_filters.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // XMOS DSP Library - Filtering Functions Test Program
 // Uses Q24 format

--- a/AN00209_xCORE-200_DSP_Library/app_fft_dif/src/app_fft.xc
+++ b/AN00209_xCORE-200_DSP_Library/app_fft_dif/src/app_fft.xc
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // XMOS DSP Library - Example to use FFT and inverse FFT
 

--- a/AN00209_xCORE-200_DSP_Library/app_fft_real_single/src/app_fft.xc
+++ b/AN00209_xCORE-200_DSP_Library/app_fft_real_single/src/app_fft.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // XMOS DSP Library - Example to use FFT and inverse FFT
 

--- a/AN00209_xCORE-200_DSP_Library/app_fft_timing/src/app_fft.xc
+++ b/AN00209_xCORE-200_DSP_Library/app_fft_timing/src/app_fft.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // XMOS DSP Library - Example to use FFT and inverse FFT
 

--- a/AN00209_xCORE-200_DSP_Library/app_window_post_fft/src/app_fft.xc
+++ b/AN00209_xCORE-200_DSP_Library/app_window_post_fft/src/app_fft.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 // XMOS DSP Library - Example to use FFT and inverse FFT
 

--- a/lib_dsp/api/dsp_bfp.h
+++ b/lib_dsp/api/dsp_bfp.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef DSP_BFP_H_

--- a/lib_dsp/api/dsp_complex.h
+++ b/lib_dsp/api/dsp_complex.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef DSP_COMPLEX_H_

--- a/lib_dsp/api/dsp_fast_float.h
+++ b/lib_dsp/api/dsp_fast_float.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2018-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #ifndef DSP_FAST_FLOAT_H_
 #define DSP_FAST_FLOAT_H_

--- a/lib_dsp/api/dsp_fp.h
+++ b/lib_dsp/api/dsp_fp.h
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef DSP_FP_H_

--- a/lib_dsp/api/dsp_math_int.h
+++ b/lib_dsp/api/dsp_math_int.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #ifndef DSP_MATH_INT_H_

--- a/lib_dsp/src/bfp/dsp_bfp_bit_reverse_shl.S
+++ b/lib_dsp/src/bfp/dsp_bfp_bit_reverse_shl.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/bfp/dsp_bfp_cls.S
+++ b/lib_dsp/src/bfp/dsp_bfp_cls.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/bfp/dsp_bfp_shl.S
+++ b/lib_dsp/src/bfp/dsp_bfp_shl.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/dsp_complex_add_vector.S
+++ b/lib_dsp/src/dsp_complex_add_vector.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/dsp_complex_fir.S
+++ b/lib_dsp/src/dsp_complex_fir.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/dsp_complex_hann.S
+++ b/lib_dsp/src/dsp_complex_hann.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/dsp_complex_mul_vector.S
+++ b/lib_dsp/src/dsp_complex_mul_vector.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/dsp_fast_atan.S
+++ b/lib_dsp/src/dsp_fast_atan.S
@@ -1,4 +1,4 @@
-// Copyright 2016-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/dsp_fast_float.xc
+++ b/lib_dsp/src/dsp_fast_float.xc
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2018-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <xclib.h>

--- a/lib_dsp/src/dsp_logistics.S
+++ b/lib_dsp/src/dsp_logistics.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/dsp_min_vector.S
+++ b/lib_dsp/src/dsp_min_vector.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/dsp_poly_eval.S
+++ b/lib_dsp/src/dsp_poly_eval.S
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/dsp_sqrt.xc
+++ b/lib_dsp/src/dsp_sqrt.xc
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2018-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "dsp_math.h"
 

--- a/lib_dsp/src/dsp_sqrt_xs2.S
+++ b/lib_dsp/src/dsp_sqrt_xs2.S
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 	.section	.dp.data,"awd",@progbits

--- a/lib_dsp/src/fft/dsp_fft_bit_reverse.S
+++ b/lib_dsp/src/fft/dsp_fft_bit_reverse.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/fft/dsp_fft_gc.S
+++ b/lib_dsp/src/fft/dsp_fft_gc.S
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/fft/dsp_fft_real_fix.S
+++ b/lib_dsp/src/fft/dsp_fft_real_fix.S
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2015-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
     
 #if (defined(__XS2A__) || defined (__XS3A__))

--- a/lib_dsp/src/float/floating_fft.xc
+++ b/lib_dsp/src/float/floating_fft.xc
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <math.h>
 #include <string.h>

--- a/lib_dsp/src/testing/dsp_testing_rand.c
+++ b/lib_dsp/src/testing/dsp_testing_rand.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <dsp_testing.h>
 #include <xs1.h>

--- a/tests/dsp_unit_tests/conftest.py
+++ b/tests/dsp_unit_tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 XMOS LIMITED.
+# Copyright 2018-2021 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import os.path
 import pytest

--- a/tests/dsp_unit_tests/src/test_bfp.c
+++ b/tests/dsp_unit_tests/src/test_bfp.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "unity.h"
 

--- a/tests/dsp_unit_tests/src/test_fft.c
+++ b/tests/dsp_unit_tests/src/test_fft.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2018-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 
 #include <xs1.h>

--- a/tests/dsp_unit_tests/src/test_testing.c
+++ b/tests/dsp_unit_tests/src/test_testing.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "unity.h"
 

--- a/tests/dsp_unit_tests/src/test_vector_bfp.c
+++ b/tests/dsp_unit_tests/src/test_vector_bfp.c
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 XMOS LIMITED.
+// Copyright 2017-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include "unity.h"
 

--- a/tests/test_biquad/conftest.py
+++ b/tests/test_biquad/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 XMOS LIMITED.
+# Copyright 2018-2021 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import os.path
 import pytest

--- a/tests/test_fft_forward_real/src/test.xc
+++ b/tests/test_fft_forward_real/src/test.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <xclib.h>

--- a/tests/test_fft_inverse_blank_forward/src/test.xc
+++ b/tests/test_fft_inverse_blank_forward/src/test.xc
@@ -1,4 +1,4 @@
-// Copyright 2017-2021 XMOS LIMITED.
+// Copyright 2016-2021 XMOS LIMITED.
 // This Software is subject to the terms of the XMOS Public Licence: Version 1.
 #include <xs1.h>
 #include <xclib.h>


### PR DESCRIPTION
With the fix to the source checking script in infr_apps, the original copyright years can be re-applied.