### PR TITLE
Fix vector absolute value function

### DIFF
--- a/AN00209_xCORE-200_DSP_Library/app_vector/src/app_vector.xc
+++ b/AN00209_xCORE-200_DSP_Library/app_vector/src/app_vector.xc
@@ -12,6 +12,7 @@
 
 #define SAMPLE_LENGTH         50
 #define SHORT_SAMPLE_LENGTH   5
+#define ABS_NEGATE_Q_ELE_CNT  2
 
 #define COMPLEX_VECTOR_LENGTH 12
 
@@ -24,6 +25,7 @@ int32_t  Src[] = { Q24(.11), Q24(.12), Q24(.13), Q24(.14), Q24(.15), Q24(.16), Q
 int32_t  Src2[] = { Q24(.51), Q24(.52), Q24(.53), Q24(.54), Q24(.55), Q24(.56), Q24(.57), Q24(.58), Q24(.59), Q24(.60)};
 int32_t  Src3[] = { Q24(.61), Q24(.62), Q24(.63), Q24(.64), Q24(.65), Q24(.66), Q24(.67), Q24(.68), Q24(.69), Q24(.70)};
 int32_t  Src4[] = { Q24(.51), Q24(-.31), Q24(0), Q24(.64), Q24(-0.3), Q24(.60), Q24(.67), Q24(.68), Q24(.69), Q24(.71)};
+int32_t  Src5[] = { Q24(.11), Q24(-.12), 0, INT32_MAX, INT32_MIN};
 int32_t  Dst[SAMPLE_LENGTH];
 
 int32_t A_real[] = {Q24(1.), Q24(2.), Q24(3.), Q24(4.), Q24(3.), Q24(4.), Q24(1.), Q24(2.), Q24(1.), Q24(3.), Q24(5.), Q24(7.)};
@@ -64,24 +66,38 @@ int main(void)
   printf ("Maximum location = %d\n", result);
   printf ("Maximum = %lf\n", F24 (Src[result]));
 
-  dsp_vector_negate (Src,                       // Input vector
+  dsp_vector_negate (Src5,                      // Input vector
                      Dst,                       // Output vector
                      SHORT_SAMPLE_LENGTH);      // Vector length
 
   printf ("Vector Negate Result\n");
   for (i = 0; i < SHORT_SAMPLE_LENGTH; i++)
   {
-    printf ("Dst[%d] = %lf\n", i, F24 (Dst[i]));
+    if (i < ABS_NEGATE_Q_ELE_CNT )
+    {
+      printf ("Dst[%d] = %lf\n", i, F24 (Dst[i]));
+    }
+    else
+    {
+      printf ("Dst[%d] = %d\n", i, Dst[i]);
+    }
   }
 
-  dsp_vector_abs (Src,                          // Input vector
+  dsp_vector_abs (Src5,                         // Input vector
                   Dst,                          // Output vector
                   SHORT_SAMPLE_LENGTH);         // Vector length
 
   printf ("Vector Absolute Result\n");
   for (i = 0; i < SHORT_SAMPLE_LENGTH; i++)
   {
-    printf ("Dst[%d] = %lf\n", i, F24 (Dst[i]));
+    if (i < ABS_NEGATE_Q_ELE_CNT )
+    {
+      printf ("Dst[%d] = %lf\n", i, F24 (Dst[i]));
+    }
+    else
+    {
+      printf ("Dst[%d] = %d\n", i, Dst[i]);
+    }
   }
 
   dsp_vector_adds (Src,                         // Input vector

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ xCORE-200 DSP library change log
 -----
 
   * CHANGED: Use XMOS Public Licence Version 1
+  * CHANGED: dsp_vector_abs function to always return positive values
 
 6.1.0
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,6 @@ xCORE-200 DSP library change log
 -----
 
   * CHANGED: Use XMOS Public Licence Version 1
-  * CHANGED: dsp_vector_abs function to always return positive values
 
 6.1.0
 -----

--- a/lib_dsp/src/dsp_vector.c
+++ b/lib_dsp/src/dsp_vector.c
@@ -174,6 +174,16 @@ int32_t dsp_vector_maximum
 
 
 
+static int32_t int32_negate
+(
+    const int32_t x
+) {
+    int32_t ret_val = ( x == INT32_MIN ) ? INT32_MAX : -x;
+    return ret_val;
+}
+
+
+
 void dsp_vector_negate
 (
     const int32_t* input_vector_X,
@@ -185,10 +195,10 @@ void dsp_vector_negate
     while( vl >= 4 )
     {
         asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        x0 = -x0; x1 = -x1;
+        x0 = int32_negate(x0); x1 = int32_negate(x1);
         asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
         asm("ldd %0,%1,%2[1]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        x0 = -x0; x1 = -x1;
+        x0 = int32_negate(x0); x1 = int32_negate(x1);
         asm("std %0,%1,%2[1]"::"r"(x1), "r"(x0),"r"(result_vector_R));
         vl -= 4; input_vector_X += 4; result_vector_R += 4;
     }
@@ -196,17 +206,17 @@ void dsp_vector_negate
     {
         case 3:
         asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        x0 = -x0; x1 = -x1;
+        x0 = int32_negate(x0); x1 = int32_negate(x1);
         asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        result_vector_R[2] = -input_vector_X[2];
+        result_vector_R[2] = int32_negate(input_vector_X[2]);
         break;
         case 2:
         asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        x0 = -x0; x1 = -x1;
+        x0 = int32_negate(x0); x1 = int32_negate(x1);
         asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
         break;
         case 1:
-        result_vector_R[0] = -input_vector_X[0];
+        result_vector_R[0] = int32_negate(input_vector_X[0]);
         break;
     }
 }
@@ -224,10 +234,10 @@ void dsp_vector_abs
     while( vl >= 4 )
     {
         asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = -x0; if( x1 < 0 ) x1 = -x1;
+        if( x0 < 0 ) x0 = int32_negate(x0); if( x1 < 0 ) x1 = int32_negate(x1);
         asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
         asm("ldd %0,%1,%2[1]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = -x0; if( x1 < 0 ) x1 = -x1;
+        if( x0 < 0 ) x0 = int32_negate(x0); if( x1 < 0 ) x1 = int32_negate(x1);
         asm("std %0,%1,%2[1]"::"r"(x1), "r"(x0),"r"(result_vector_R));
         vl -= 4; input_vector_X += 4; result_vector_R += 4;
     }
@@ -235,17 +245,17 @@ void dsp_vector_abs
     {
         case 3:
         asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = -x0; if( x1 < 0 ) x1 = -x1;
+        if( x0 < 0 ) x0 = int32_negate(x0); if( x1 < 0 ) x1 = int32_negate(x1);
         asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        result_vector_R[2] = ( input_vector_X[2] < 0 ) ? -input_vector_X[2] : input_vector_X[2];
+        result_vector_R[2] = ( input_vector_X[2] < 0 ) ? int32_negate(input_vector_X[2]) : input_vector_X[2];
         break;
         case 2:
         asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = -x0; if( x1 < 0 ) x1 = -x1;
+        if( x0 < 0 ) x0 = int32_negate(x0); if( x1 < 0 ) x1 = int32_negate(x1);
         asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
         break;
         case 1:
-        result_vector_R[0] = ( input_vector_X[0] < 0 ) ? -input_vector_X[0] : input_vector_X[0];
+        result_vector_R[0] = ( input_vector_X[0] < 0 ) ? int32_negate(input_vector_X[0]) : input_vector_X[0];
         break;
     }
 }

--- a/lib_dsp/src/dsp_vector.c
+++ b/lib_dsp/src/dsp_vector.c
@@ -190,34 +190,9 @@ void dsp_vector_negate
     int32_t*       result_vector_R,
     const int32_t  vector_length
 ) {
-    int32_t x1, x0;
-    int32_t vl = vector_length;  
-    while( vl >= 4 )
+    for( int32_t i = 0; i < vector_length; ++i )
     {
-        asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        x0 = int32_negate(x0); x1 = int32_negate(x1);
-        asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        asm("ldd %0,%1,%2[1]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        x0 = int32_negate(x0); x1 = int32_negate(x1);
-        asm("std %0,%1,%2[1]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        vl -= 4; input_vector_X += 4; result_vector_R += 4;
-    }
-    switch( vl )
-    {
-        case 3:
-        asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        x0 = int32_negate(x0); x1 = int32_negate(x1);
-        asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        result_vector_R[2] = int32_negate(input_vector_X[2]);
-        break;
-        case 2:
-        asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        x0 = int32_negate(x0); x1 = int32_negate(x1);
-        asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        break;
-        case 1:
-        result_vector_R[0] = int32_negate(input_vector_X[0]);
-        break;
+        result_vector_R[i] = int32_negate(input_vector_X[i]);
     }
 }
 
@@ -229,34 +204,9 @@ void dsp_vector_abs
     int32_t*       result_vector_R,
     const int32_t  vector_length
 ) {
-    int32_t x1, x0;
-    int32_t vl = vector_length;  
-    while( vl >= 4 )
+    for( int32_t i = 0; i < vector_length; ++i )
     {
-        asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = int32_negate(x0); if( x1 < 0 ) x1 = int32_negate(x1);
-        asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        asm("ldd %0,%1,%2[1]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = int32_negate(x0); if( x1 < 0 ) x1 = int32_negate(x1);
-        asm("std %0,%1,%2[1]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        vl -= 4; input_vector_X += 4; result_vector_R += 4;
-    }
-    switch( vl )
-    {
-        case 3:
-        asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = int32_negate(x0); if( x1 < 0 ) x1 = int32_negate(x1);
-        asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        result_vector_R[2] = ( input_vector_X[2] < 0 ) ? int32_negate(input_vector_X[2]) : input_vector_X[2];
-        break;
-        case 2:
-        asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = int32_negate(x0); if( x1 < 0 ) x1 = int32_negate(x1);
-        asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        break;
-        case 1:
-        result_vector_R[0] = ( input_vector_X[0] < 0 ) ? int32_negate(input_vector_X[0]) : input_vector_X[0];
-        break;
+        result_vector_R[i] = ( input_vector_X[i] < 0 ) ? int32_negate(input_vector_X[i]) : input_vector_X[i];
     }
 }
 

--- a/lib_dsp/src/dsp_vector.c
+++ b/lib_dsp/src/dsp_vector.c
@@ -235,17 +235,17 @@ void dsp_vector_abs
     {
         case 3:
         asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = -x0;
+        if( x0 < 0 ) x0 = -x0; if( x1 < 0 ) x1 = -x1;
         asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
-        result_vector_R[2] = -input_vector_X[2];
+        result_vector_R[2] = ( input_vector_X[2] < 0 ) ? -input_vector_X[2] : input_vector_X[2];
         break;
         case 2:
         asm("ldd %0,%1,%2[0]":"=r"(x1),"=r"(x0):"r"(input_vector_X));
-        if( x0 < 0 ) x0 = -x0;
+        if( x0 < 0 ) x0 = -x0; if( x1 < 0 ) x1 = -x1;
         asm("std %0,%1,%2[0]"::"r"(x1), "r"(x0),"r"(result_vector_R));
         break;
         case 1:
-        result_vector_R[0] = -input_vector_X[0];
+        result_vector_R[0] = ( input_vector_X[0] < 0 ) ? -input_vector_X[0] : input_vector_X[0];
         break;
     }
 }

--- a/tests/adaptive_test.expect
+++ b/tests/adaptive_test.expect
@@ -1,4 +1,3 @@
-Forcing a reboot of the XTAG to install firmware.
 LMS 5
 +0.003133 +0.096867 
 +0.009405 +0.090595 

--- a/tests/adaptive_test.expect
+++ b/tests/adaptive_test.expect
@@ -1,3 +1,4 @@
+Forcing a reboot of the XTAG to install firmware.
 LMS 5
 +0.003133 +0.096867 
 +0.009405 +0.090595 

--- a/tests/vector_test.expect
+++ b/tests/vector_test.expect
@@ -13,7 +13,7 @@ Dst[0] = 0.110000
 Dst[1] = 0.120000
 Dst[2] = 0.130000
 Dst[3] = 0.140000
-Dst[4] = -0.150000
+Dst[4] = 0.150000
 Vector / scalar addition Result
 Dst[0] = 2.110000
 Dst[1] = 2.120000

--- a/tests/vector_test.expect
+++ b/tests/vector_test.expect
@@ -4,16 +4,16 @@ Maximum location = 49
 Maximum = 0.600000
 Vector Negate Result
 Dst[0] = -0.110000
-Dst[1] = -0.120000
-Dst[2] = -0.130000
-Dst[3] = -0.140000
-Dst[4] = -0.150000
+Dst[1] = 0.120000
+Dst[2] = 0
+Dst[3] = -2147483647
+Dst[4] = 2147483647
 Vector Absolute Result
 Dst[0] = 0.110000
 Dst[1] = 0.120000
-Dst[2] = 0.130000
-Dst[3] = 0.140000
-Dst[4] = 0.150000
+Dst[2] = 0
+Dst[3] = 2147483647
+Dst[4] = 2147483647
 Vector / scalar addition Result
 Dst[0] = 2.110000
 Dst[1] = 2.120000


### PR DESCRIPTION
The dsp_vector_abs() function previously did not convert negative vector elements to a positive in some cases.  The test used to check its operation expected a negative value when it should have expected a positive one.